### PR TITLE
Provide ipmireport endpoint, use swagger from builder image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test:
 generate-client:
 	rm -rf api
 	mkdir -p api
-	GO111MODULE=off swagger generate client -f metal-api.json -t api --skip-validation
+	GO111MODULE=off docker run -it --user $$(id -u):$$(id -g) --rm -v ${PWD}:/work metalstack/builder swagger generate client -f metal-api.json -t api --skip-validation
 
 .PHONY: golangcicheck
 golangcicheck:

--- a/machine.go
+++ b/machine.go
@@ -132,6 +132,16 @@ type MachineIPMIListResponse struct {
 	Machines []*models.V1MachineIPMIResponse
 }
 
+// MachineIPMIReport contains the machine ipmi report
+type MachineIPMIReport struct {
+	Report *models.V1MachineIPMIReport
+}
+
+// MachineIPMIReportResponse contains the machine ipmi report result
+type MachineIPMIReportResponse struct {
+	Response *models.V1MachineIPMIReportResponse
+}
+
 // MachineDeleteResponse contains the machine delete result
 type MachineDeleteResponse struct {
 	Machine *models.V1MachineResponse
@@ -378,6 +388,19 @@ func (d *Driver) MachineIPMIList(mfr *MachineFindRequest) (*MachineIPMIListRespo
 	response.Machines = resp.Payload
 
 	return response, nil
+}
+
+// MachineIPMIReport send leases of this partition to the metal-api
+func (d *Driver) MachineIPMIReport(report MachineIPMIReport) (*MachineIPMIReportResponse, error) {
+	params := machine.NewIPMIReportParams()
+	params.SetBody(report.Report)
+	ok, err := d.machine.IPMIReport(params, d.auth)
+	if err != nil {
+		return nil, err
+	}
+	return &MachineIPMIReportResponse{
+		Response: ok.Payload,
+	}, nil
 }
 
 // MachinePowerOn powers on the given machine


### PR DESCRIPTION
I want to move all clients to use metal-go, pr for ipmi-catcher is comming