### PR TITLE
Cleanup of obsolete round tripper and minor refactorings.

### DIFF
--- a/firewall.go
+++ b/firewall.go
@@ -1,9 +1,6 @@
 package metalgo
 
 import (
-	"net/http"
-	"time"
-
 	"github.com/metal-stack/metal-go/api/client/firewall"
 	"github.com/metal-stack/metal-go/api/models"
 )
@@ -56,12 +53,7 @@ func (d *Driver) FirewallCreate(fcr *FirewallCreateRequest) (*FirewallCreateResp
 	allocFirewall := firewall.NewAllocateFirewallParams()
 	allocFirewall.SetBody(allocateRequest)
 
-	retryOnlyOnStatusNotFound := func(sc int) bool {
-		return sc == http.StatusNotFound
-	}
-	allocFirewall.WithContext(newRetryContext(3, 5*time.Second, retryOnlyOnStatusNotFound))
-
-	resp, err := d.firewall.AllocateFirewall(allocFirewall, d.auth)
+	resp, err := d.firewall.AllocateFirewall(allocFirewall, nil)
 	if err != nil {
 		return response, err
 	}
@@ -75,7 +67,7 @@ func (d *Driver) FirewallList() (*FirewallListResponse, error) {
 	response := &FirewallListResponse{}
 
 	listFirewall := firewall.NewListFirewallsParams()
-	resp, err := d.firewall.ListFirewalls(listFirewall, d.auth)
+	resp, err := d.firewall.ListFirewalls(listFirewall, nil)
 	if err != nil {
 		return response, err
 	}
@@ -142,7 +134,7 @@ func (d *Driver) FirewallFind(ffr *FirewallFindRequest) (*FirewallListResponse, 
 	findFirewalls := firewall.NewFindFirewallsParams()
 	findFirewalls.SetBody(req)
 
-	resp, err = d.firewall.FindFirewalls(findFirewalls, d.auth)
+	resp, err = d.firewall.FindFirewalls(findFirewalls, nil)
 	if err != nil {
 		return response, err
 	}
@@ -156,7 +148,7 @@ func (d *Driver) FirewallGet(machineID string) (*FirewallGetResponse, error) {
 	findFirewall.ID = machineID
 
 	response := &FirewallGetResponse{}
-	resp, err := d.firewall.FindFirewall(findFirewall, d.auth)
+	resp, err := d.firewall.FindFirewall(findFirewall, nil)
 	if err != nil {
 		return response, err
 	}

--- a/image.go
+++ b/image.go
@@ -38,7 +38,7 @@ type ImageCreateResponse struct {
 func (d *Driver) ImageList() (*ImageListResponse, error) {
 	response := &ImageListResponse{}
 	listImages := image.NewListImagesParams()
-	resp, err := d.image.ListImages(listImages, d.auth)
+	resp, err := d.image.ListImages(listImages, nil)
 	if err != nil {
 		return response, err
 	}
@@ -51,7 +51,7 @@ func (d *Driver) ImageGet(imageID string) (*ImageGetResponse, error) {
 	response := &ImageGetResponse{}
 	request := image.NewFindImageParams()
 	request.ID = imageID
-	resp, err := d.image.FindImage(request, d.auth)
+	resp, err := d.image.FindImage(request, nil)
 	if err != nil {
 		return response, err
 	}
@@ -64,7 +64,7 @@ func (d *Driver) ImageGetLatest(imageID string) (*ImageGetResponse, error) {
 	response := &ImageGetResponse{}
 	request := image.NewFindLatestImageParams()
 	request.ID = imageID
-	resp, err := d.image.FindLatestImage(request, d.auth)
+	resp, err := d.image.FindLatestImage(request, nil)
 	if err != nil {
 		return response, err
 	}
@@ -85,7 +85,7 @@ func (d *Driver) ImageCreate(icr ImageCreateRequest) (*ImageCreateResponse, erro
 	}
 	request := image.NewCreateImageParams()
 	request.SetBody(createImage)
-	resp, err := d.image.CreateImage(request, d.auth)
+	resp, err := d.image.CreateImage(request, nil)
 	if err != nil {
 		return response, err
 	}
@@ -114,7 +114,7 @@ func (d *Driver) ImageUpdate(icr ImageCreateRequest) (*ImageCreateResponse, erro
 
 	request := image.NewUpdateImageParams()
 	request.SetBody(updateImage)
-	resp, err := d.image.UpdateImage(request, d.auth)
+	resp, err := d.image.UpdateImage(request, nil)
 	if err != nil {
 		return response, err
 	}
@@ -127,7 +127,7 @@ func (d *Driver) ImageDelete(imageID string) (*ImageGetResponse, error) {
 	response := &ImageGetResponse{}
 	request := image.NewDeleteImageParams()
 	request.ID = imageID
-	resp, err := d.image.DeleteImage(request, d.auth)
+	resp, err := d.image.DeleteImage(request, nil)
 	if err != nil {
 		return response, err
 	}

--- a/machine.go
+++ b/machine.go
@@ -1,9 +1,6 @@
 package metalgo
 
 import (
-	"net/http"
-	"time"
-
 	"github.com/metal-stack/metal-go/api/client/machine"
 	"github.com/metal-stack/metal-go/api/models"
 )
@@ -189,12 +186,7 @@ func (d *Driver) MachineCreate(mcr *MachineCreateRequest) (*MachineCreateRespons
 	allocMachine := machine.NewAllocateMachineParams()
 	allocMachine.SetBody(allocateRequest)
 
-	retryOnlyOnStatusNotFound := func(sc int) bool {
-		return sc == http.StatusNotFound
-	}
-	allocMachine.WithContext(newRetryContext(3, 5*time.Second, retryOnlyOnStatusNotFound))
-
-	resp, err := d.machine.AllocateMachine(allocMachine, d.auth)
+	resp, err := d.machine.AllocateMachine(allocMachine, nil)
 	if err != nil {
 		return response, err
 	}
@@ -210,7 +202,7 @@ func (d *Driver) MachineDelete(machineID string) (*MachineDeleteResponse, error)
 	freeMachine.ID = machineID
 
 	response := &MachineDeleteResponse{}
-	resp, err := d.machine.FreeMachine(freeMachine, d.auth)
+	resp, err := d.machine.FreeMachine(freeMachine, nil)
 	if err != nil {
 		return response, err
 	}
@@ -224,7 +216,7 @@ func (d *Driver) MachineGet(id string) (*MachineGetResponse, error) {
 	findMachine.ID = id
 
 	response := &MachineGetResponse{}
-	resp, err := d.machine.FindMachine(findMachine, d.auth)
+	resp, err := d.machine.FindMachine(findMachine, nil)
 	if err != nil {
 		return response, err
 	}
@@ -237,7 +229,7 @@ func (d *Driver) MachineGet(id string) (*MachineGetResponse, error) {
 func (d *Driver) MachineList() (*MachineListResponse, error) {
 	listMachines := machine.NewListMachinesParams()
 	response := &MachineListResponse{}
-	resp, err := d.machine.ListMachines(listMachines, d.auth)
+	resp, err := d.machine.ListMachines(listMachines, nil)
 	if err != nil {
 		return response, err
 	}
@@ -305,7 +297,7 @@ func (d *Driver) MachineFind(mfr *MachineFindRequest) (*MachineListResponse, err
 	}
 	findMachines.SetBody(req)
 
-	resp, err = d.machine.FindMachines(findMachines, d.auth)
+	resp, err = d.machine.FindMachines(findMachines, nil)
 	if err != nil {
 		return response, err
 	}
@@ -319,7 +311,7 @@ func (d *Driver) MachineIPMIGet(id string) (*MachineIPMIGetResponse, error) {
 	findMachine := machine.NewFindIPMIMachineParams().WithID(id)
 
 	response := &MachineIPMIGetResponse{}
-	resp, err := d.machine.FindIPMIMachine(findMachine, d.auth)
+	resp, err := d.machine.FindIPMIMachine(findMachine, nil)
 	if err != nil {
 		return response, err
 	}
@@ -381,7 +373,7 @@ func (d *Driver) MachineIPMIList(mfr *MachineFindRequest) (*MachineIPMIListRespo
 	}
 	findMachines.SetBody(req)
 
-	resp, err := d.machine.FindIPMIMachines(findMachines, d.auth)
+	resp, err := d.machine.FindIPMIMachines(findMachines, nil)
 	if err != nil {
 		return response, err
 	}
@@ -394,7 +386,7 @@ func (d *Driver) MachineIPMIList(mfr *MachineFindRequest) (*MachineIPMIListRespo
 func (d *Driver) MachineIPMIReport(report MachineIPMIReport) (*MachineIPMIReportResponse, error) {
 	params := machine.NewIPMIReportParams()
 	params.SetBody(report.Report)
-	ok, err := d.machine.IPMIReport(params, d.auth)
+	ok, err := d.machine.IPMIReport(params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -410,7 +402,7 @@ func (d *Driver) MachinePowerOn(machineID string) (*MachinePowerResponse, error)
 	machineOn.Body = []string{}
 
 	response := &MachinePowerResponse{}
-	resp, err := d.machine.MachineOn(machineOn, d.auth)
+	resp, err := d.machine.MachineOn(machineOn, nil)
 	if err != nil {
 		return response, err
 	}
@@ -425,7 +417,7 @@ func (d *Driver) MachinePowerOff(machineID string) (*MachinePowerResponse, error
 	machineOff.Body = []string{}
 
 	response := &MachinePowerResponse{}
-	resp, err := d.machine.MachineOff(machineOff, d.auth)
+	resp, err := d.machine.MachineOff(machineOff, nil)
 	if err != nil {
 		return response, err
 	}
@@ -440,7 +432,7 @@ func (d *Driver) MachinePowerReset(machineID string) (*MachinePowerResponse, err
 	machineReset.Body = []string{}
 
 	response := &MachinePowerResponse{}
-	resp, err := d.machine.MachineReset(machineReset, d.auth)
+	resp, err := d.machine.MachineReset(machineReset, nil)
 	if err != nil {
 		return response, err
 	}
@@ -455,7 +447,7 @@ func (d *Driver) MachineBootBios(machineID string) (*MachineBiosResponse, error)
 	machineBios.Body = []string{}
 
 	response := &MachineBiosResponse{}
-	resp, err := d.machine.MachineBios(machineBios, d.auth)
+	resp, err := d.machine.MachineBios(machineBios, nil)
 	if err != nil {
 		return response, err
 	}
@@ -494,7 +486,7 @@ func (d *Driver) MachineReinstall(machineID, imageID, description string) (*Mach
 	machineReinstall.Body = request
 
 	response := &MachineGetResponse{}
-	resp, err := d.machine.ReinstallMachine(machineReinstall, d.auth)
+	resp, err := d.machine.ReinstallMachine(machineReinstall, nil)
 	if err != nil {
 		return response, err
 	}
@@ -511,7 +503,7 @@ func (d *Driver) machineState(machineID, state, description string) (*MachineSta
 	}
 
 	response := &MachineStateResponse{}
-	resp, err := d.machine.SetMachineState(machineState, d.auth)
+	resp, err := d.machine.SetMachineState(machineState, nil)
 	if err != nil {
 		return response, err
 	}
@@ -527,7 +519,7 @@ func (d *Driver) ChassisIdentifyLEDPowerOn(machineID, description string) (*Chas
 	machineLedOn.Body = []string{}
 
 	response := &ChassisIdentifyLEDPowerResponse{}
-	resp, err := d.machine.ChassisIdentifyLEDOn(machineLedOn, d.auth)
+	resp, err := d.machine.ChassisIdentifyLEDOn(machineLedOn, nil)
 	if err != nil {
 		return response, err
 	}
@@ -543,7 +535,7 @@ func (d *Driver) ChassisIdentifyLEDPowerOff(machineID, description string) (*Cha
 	machineLedOff.Body = []string{}
 
 	response := &ChassisIdentifyLEDPowerResponse{}
-	resp, err := d.machine.ChassisIdentifyLEDOff(machineLedOff, d.auth)
+	resp, err := d.machine.ChassisIdentifyLEDOff(machineLedOff, nil)
 	if err != nil {
 		return response, err
 	}

--- a/machine_test.go
+++ b/machine_test.go
@@ -1,19 +1,15 @@
 package metalgo
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/emicklei/go-restful/v3"
-	"github.com/metal-stack/metal-go/api/client/machine"
 	"github.com/metal-stack/metal-go/api/models"
 	"github.com/stretchr/testify/require"
 )
@@ -59,199 +55,6 @@ func TestMachineCreate(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, metalMachine, resp.Machine)
-}
-
-func TestRetryAllocateMachine(t *testing.T) {
-	// given
-	errMsg := "Faked error"
-	attemptTracker := &sync.Map{}
-	machineID := "machineID"
-	metalMachine := &models.V1MachineResponse{
-		ID: &machineID,
-	}
-	ws.Routes()[0].Function = func(req *restful.Request, resp *restful.Response) {
-		reqBody, _ := ioutil.ReadAll(req.Request.Body)
-		allocMachineRequest := &models.V1MachineAllocateRequest{}
-		_ = json.Unmarshal(reqBody, allocMachineRequest)
-
-		value, _ := attemptTracker.LoadOrStore(allocMachineRequest.UserData, 0)
-		attempt := value.(int)
-		attempt++
-		attemptTracker.Store(allocMachineRequest.UserData, attempt)
-		if attempt < 4 {
-			err := models.HttperrorsHTTPErrorResponse{
-				Message: &errMsg,
-			}
-			errResp, _ := json.Marshal(err)
-			_ = resp.WriteErrorString(http.StatusNotFound, string(errResp))
-
-			return
-		}
-
-		_ = resp.WriteEntity(metalMachine)
-	}
-
-	server, driver := startServerAndGetDriver()
-	defer func() {
-		_ = server.Close()
-	}()
-
-	var wg sync.WaitGroup
-	wg.Add(7)
-
-	// Verify failure with retry config that will be applied due to a matching status code but having not enough retries configured
-	go func() {
-		defer wg.Done()
-
-		// given
-		allocMachineRequest := &models.V1MachineAllocateRequest{
-			UserData: "1",
-		}
-		allocMachine := machine.NewAllocateMachineParams()
-		allocMachine.SetBody(allocMachineRequest)
-		allocMachine.WithContext(newRetryContext(2, 5*time.Millisecond, func(sc int) bool {
-			return sc == http.StatusNotFound
-		}))
-
-		// when
-		resp, err := driver.machine.AllocateMachine(allocMachine, driver.auth)
-
-		// then
-		require.NotNil(t, err)
-		require.Contains(t, err.Error(), errMsg)
-		require.Nil(t, resp)
-	}()
-
-	// Verify success with retry config that will be applied due to a matching status code
-	go func() {
-		defer wg.Done()
-
-		// given
-		allocMachineRequest := &models.V1MachineAllocateRequest{
-			UserData: "2",
-		}
-		allocMachine := machine.NewAllocateMachineParams()
-		allocMachine.SetBody(allocMachineRequest)
-		allocMachine.SetContext(newRetryContext(3, 4*time.Millisecond, func(sc int) bool {
-			return sc == http.StatusNotFound
-		}))
-
-		// when
-		resp, err := driver.machine.AllocateMachine(allocMachine, driver.auth)
-
-		// then
-		require.Nil(t, err)
-		require.NotNil(t, resp)
-		require.Equal(t, metalMachine, resp.Payload)
-	}()
-
-	// Verify success with retry config that will always be applied
-	go func() {
-		defer wg.Done()
-
-		// given
-		allocMachineRequest := &models.V1MachineAllocateRequest{
-			UserData: "3",
-		}
-		allocMachine := machine.NewAllocateMachineParams()
-		allocMachine.SetBody(allocMachineRequest)
-		allocMachine.WithContext(newRetryContext(3, 3*time.Millisecond))
-
-		// when
-		resp, err := driver.machine.AllocateMachine(allocMachine, driver.auth)
-
-		// then
-		require.Nil(t, err)
-		require.NotNil(t, resp)
-		require.Equal(t, metalMachine, resp.Payload)
-	}()
-
-	// Verify success with retry config that will be applied due to a matching status code
-	go func() {
-		defer wg.Done()
-
-		// given
-		allocMachineRequest := &models.V1MachineAllocateRequest{
-			UserData: "4",
-		}
-		allocMachine := machine.NewAllocateMachineParams()
-		allocMachine.SetBody(allocMachineRequest)
-		allocMachine.SetContext(newRetryContext(3, 2*time.Millisecond, func(sc int) bool {
-			return sc == http.StatusBadRequest || sc == http.StatusNotFound
-		}))
-
-		// when
-		resp, err := driver.machine.AllocateMachine(allocMachine, driver.auth)
-
-		// then
-		require.Nil(t, err)
-		require.NotNil(t, resp)
-		require.Equal(t, metalMachine, resp.Payload)
-	}()
-
-	// Verify failure with retry config that will not be applied due to a non-matching status code
-	go func() {
-		defer wg.Done()
-
-		// given
-		allocMachineRequest := &models.V1MachineAllocateRequest{
-			UserData: "5",
-		}
-		allocMachine := machine.NewAllocateMachineParams()
-		allocMachine.SetBody(allocMachineRequest)
-		allocMachine.WithContext(newRetryContext(3, time.Millisecond, func(sc int) bool {
-			return sc == http.StatusBadRequest
-		}))
-
-		// when
-		resp, err := driver.machine.AllocateMachine(allocMachine, driver.auth)
-
-		// then
-		require.NotNil(t, err)
-		require.Contains(t, err.Error(), errMsg)
-		require.Nil(t, resp)
-	}()
-
-	// Verify failure due to a lacking retry config
-	go func() {
-		defer wg.Done()
-
-		// given
-		allocMachineRequest := &models.V1MachineAllocateRequest{
-			UserData: "6",
-		}
-		allocMachine := machine.NewAllocateMachineParams()
-		allocMachine.SetBody(allocMachineRequest)
-
-		// when
-		resp, err := driver.machine.AllocateMachine(allocMachine, driver.auth)
-
-		// then
-		require.NotNil(t, err)
-		require.Contains(t, err.Error(), errMsg)
-		require.Nil(t, resp)
-	}()
-
-	// Verify success with nil body
-	go func() {
-		defer wg.Done()
-
-		// given
-		allocMachine := machine.NewAllocateMachineParams()
-		allocMachine.WithContext(newRetryContext(3, time.Millisecond, func(sc int) bool {
-			return sc == http.StatusNotFound
-		}))
-
-		// when
-		resp, err := driver.machine.AllocateMachine(allocMachine, driver.auth)
-
-		// then
-		require.Nil(t, err)
-		require.NotNil(t, resp)
-		require.Equal(t, metalMachine, resp.Payload)
-	}()
-
-	wg.Wait()
 }
 
 func startServerAndGetDriver() (*http.Server, *Driver) {

--- a/metal.go
+++ b/metal.go
@@ -27,6 +27,7 @@ const (
 
 // Driver holds the client connection to the metal api
 type Driver struct {
+	client       *client.Metal
 	image        *image.Client
 	machine      *machine.Client
 	firewall     *firewall.Client
@@ -65,6 +66,7 @@ func NewDriver(baseURL, bearer, hmacKey string, options ...option) (*Driver, err
 	client := client.New(transport, strfmt.Default)
 
 	driver := &Driver{
+		client:       client,
 		machine:      client.Machine,
 		firewall:     client.Firewall,
 		size:         client.Size,

--- a/metal.go
+++ b/metal.go
@@ -1,18 +1,14 @@
 package metalgo
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/metal-stack/metal-go/api/client"
 	"github.com/metal-stack/metal-go/api/client/firewall"
 	"github.com/metal-stack/metal-go/api/client/image"
 	"github.com/metal-stack/metal-go/api/client/ip"
@@ -22,26 +18,27 @@ import (
 	"github.com/metal-stack/metal-go/api/client/project"
 	"github.com/metal-stack/metal-go/api/client/size"
 	sw "github.com/metal-stack/metal-go/api/client/switch_operations"
-	"github.com/metal-stack/metal-go/api/models"
 	"github.com/metal-stack/security"
-	"github.com/pkg/errors"
+)
+
+const (
+	defaultHMACAuthType = "Metal-Admin"
 )
 
 // Driver holds the client connection to the metal api
 type Driver struct {
-	image     *image.Client
-	machine   *machine.Client
-	firewall  *firewall.Client
-	partition *partition.Client
-	project   *project.Client
-	size      *size.Client
-	sw        *sw.Client
-	network   *network.Client
-	ip        *ip.Client
-	auth      runtime.ClientAuthInfoWriter
-	bearer    string
-	authType  string
-	hmac      *security.HMACAuth
+	image        *image.Client
+	machine      *machine.Client
+	firewall     *firewall.Client
+	partition    *partition.Client
+	project      *project.Client
+	size         *size.Client
+	sw           *sw.Client
+	network      *network.Client
+	ip           *ip.Client
+	bearer       string
+	hmacAuthType string
+	hmac         *security.HMACAuth
 }
 
 // Option for config of Driver
@@ -50,14 +47,12 @@ type option func(driver *Driver)
 // AuthType sets the authType for HMAC-Auth
 func AuthType(authType string) option {
 	return func(driver *Driver) {
-		driver.authType = authType
+		driver.hmacAuthType = authType
 	}
 }
 
 // NewDriver Create a new Driver for Metal to given url. Either bearer OR hmacKey must be set.
 func NewDriver(baseURL, bearer, hmacKey string, options ...option) (*Driver, error) {
-	roundTripper := &roundTripper{}
-
 	parsedURL, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, err
@@ -67,20 +62,20 @@ func NewDriver(baseURL, bearer, hmacKey string, options ...option) (*Driver, err
 	}
 
 	transport := httptransport.New(parsedURL.Host, parsedURL.Path, []string{parsedURL.Scheme})
-	transport.Transport = roundTripper
+	client := client.New(transport, strfmt.Default)
 
 	driver := &Driver{
-		machine:   machine.New(transport, strfmt.Default),
-		firewall:  firewall.New(transport, strfmt.Default),
-		size:      size.New(transport, strfmt.Default),
-		image:     image.New(transport, strfmt.Default),
-		project:   project.New(transport, strfmt.Default),
-		partition: partition.New(transport, strfmt.Default),
-		sw:        sw.New(transport, strfmt.Default),
-		network:   network.New(transport, strfmt.Default),
-		ip:        ip.New(transport, strfmt.Default),
-		bearer:    bearer,
-		authType:  "Metal-Admin",
+		machine:      client.Machine,
+		firewall:     client.Firewall,
+		size:         client.Size,
+		image:        client.Image,
+		project:      client.Project,
+		partition:    client.Partition,
+		sw:           client.SwitchOperations,
+		network:      client.Network,
+		ip:           client.IP,
+		bearer:       bearer,
+		hmacAuthType: defaultHMACAuthType,
 	}
 
 	for _, opt := range options {
@@ -88,10 +83,11 @@ func NewDriver(baseURL, bearer, hmacKey string, options ...option) (*Driver, err
 	}
 
 	if hmacKey != "" {
-		auth := security.NewHMACAuth(driver.authType, []byte(hmacKey))
+		auth := security.NewHMACAuth(driver.hmacAuthType, []byte(hmacKey))
 		driver.hmac = &auth
 	}
-	driver.auth = runtime.ClientAuthInfoWriterFunc(driver.auther)
+
+	transport.DefaultAuthentication = runtime.ClientAuthInfoWriterFunc(driver.auther)
 
 	return driver, nil
 }
@@ -103,111 +99,6 @@ func (d *Driver) auther(rq runtime.ClientRequest, rg strfmt.Registry) error {
 		security.AddUserTokenToClientRequest(rq, d.bearer)
 	}
 	return nil
-}
-
-// roundTripper is used to intercept api responses.
-type roundTripper struct{}
-
-// retryConfig is used to manage request retry behaviour.
-type retryConfig struct {
-	retriesLeft     uint
-	delay           time.Duration
-	retryConditions []func(statusCode int) bool
-}
-
-type retryKey string
-
-const retryConfigKey = retryKey("retryConfig")
-
-// newRetryContext creates and returns a new retry context.
-// If assigned to a Swagger request that request will be retried up to maxAttempts with given delay
-// in between as long as the responses indicate an error (i.e. status code >= 400) and none of the
-// given retry conditions fails.
-func newRetryContext(maxAttempts uint, delay time.Duration, retryConditions ...func(statusCode int) bool) context.Context {
-	if maxAttempts == 0 {
-		return nil
-	}
-
-	if delay <= 0 {
-		delay = 5 * time.Second
-	}
-
-	rc := &retryConfig{
-		retriesLeft:     maxAttempts,
-		delay:           delay,
-		retryConditions: retryConditions,
-	}
-
-	return context.WithValue(context.Background(), retryConfigKey, rc)
-}
-
-func (r *retryConfig) shouldRetryOn(statusCode int) bool {
-	if r == nil || statusCode < 400 || r.retriesLeft == 0 {
-		return false
-	}
-
-	for _, condition := range r.retryConditions {
-		if !condition(statusCode) {
-			return false
-		}
-	}
-
-	return true
-}
-
-func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	var reqBody []byte
-	if req.Body != nil {
-		var err error
-		reqBody, err = ioutil.ReadAll(req.Body)
-		if err != nil {
-			return nil, err
-		}
-		req.Body.Close()
-		req.Body = ioutil.NopCloser(strings.NewReader(string(reqBody)))
-	}
-
-	resp, err := http.DefaultTransport.RoundTrip(req)
-	if err != nil {
-		return nil, err
-	}
-
-	statusCode := resp.StatusCode
-
-	rc, ok := req.Context().Value(retryConfigKey).(*retryConfig)
-	if ok && rc.shouldRetryOn(statusCode) {
-		time.Sleep(rc.delay)
-		rc.retriesLeft--
-		if reqBody != nil {
-			req.Body = ioutil.NopCloser(strings.NewReader(string(reqBody)))
-		}
-		return r.RoundTrip(req)
-	}
-
-	switch statusCode {
-	case http.StatusMovedPermanently, http.StatusTemporaryRedirect, http.StatusPermanentRedirect:
-		return nil, errors.New("got redirect which is impossible")
-	case http.StatusInternalServerError:
-		return nil, errors.New("internal server error, please check server logs for details")
-	default:
-		if statusCode >= 400 {
-			// domain errors must be in json to be able to distinguish from technical issues.
-			respBody, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				return nil, errors.Wrap(err, "error reading error response")
-			}
-			resp.Body.Close()
-
-			errorResponse := &models.HttperrorsHTTPErrorResponse{}
-			err = json.Unmarshal(respBody, errorResponse)
-			if err != nil {
-				return nil, errors.Errorf("endpoint did not follow our error conventions:%s", string(respBody))
-			}
-			return nil, errors.New(*errorResponse.Message)
-		}
-
-		return resp, nil
-	}
 }
 
 func StrDeref(s *string) string {

--- a/network.go
+++ b/network.go
@@ -196,7 +196,7 @@ func (d *Driver) NetworkGet(id string) (*NetworkGetResponse, error) {
 	findNetwork.ID = id
 
 	response := &NetworkGetResponse{}
-	resp, err := d.network.FindNetwork(findNetwork, d.auth)
+	resp, err := d.network.FindNetwork(findNetwork, nil)
 	if err != nil {
 		return response, err
 	}
@@ -209,7 +209,7 @@ func (d *Driver) NetworkGet(id string) (*NetworkGetResponse, error) {
 func (d *Driver) NetworkList() (*NetworkListResponse, error) {
 	response := &NetworkListResponse{}
 	listNetworks := network.NewListNetworksParams()
-	resp, err := d.network.ListNetworks(listNetworks, d.auth)
+	resp, err := d.network.ListNetworks(listNetworks, nil)
 	if err != nil {
 		return response, err
 	}
@@ -244,7 +244,7 @@ func (d *Driver) NetworkFind(nfr *NetworkFindRequest) (*NetworkListResponse, err
 	}
 	findNetworks.SetBody(req)
 
-	resp, err = d.network.FindNetworks(findNetworks, d.auth)
+	resp, err = d.network.FindNetworks(findNetworks, nil)
 	if err != nil {
 		return response, err
 	}
@@ -273,7 +273,7 @@ func (d *Driver) NetworkCreate(ncr *NetworkCreateRequest) (*NetworkDetailRespons
 		Underlay:            &ncr.Underlay,
 	}
 	createNetwork.SetBody(createRequest)
-	resp, err := d.network.CreateNetwork(createNetwork, d.auth)
+	resp, err := d.network.CreateNetwork(createNetwork, nil)
 	if err != nil {
 		return response, err
 	}
@@ -294,7 +294,7 @@ func (d *Driver) NetworkAllocate(ncr *NetworkAllocateRequest) (*NetworkDetailRes
 		Labels:      ncr.Labels,
 	}
 	acquireNetwork.SetBody(acquireRequest)
-	resp, err := d.network.AllocateNetwork(acquireNetwork, d.auth)
+	resp, err := d.network.AllocateNetwork(acquireNetwork, nil)
 	if err != nil {
 		return response, err
 	}
@@ -308,7 +308,7 @@ func (d *Driver) NetworkFree(id string) (*NetworkDetailResponse, error) {
 	releaseNetwork := network.NewFreeNetworkParams()
 
 	releaseNetwork.ID = id
-	resp, err := d.network.FreeNetwork(releaseNetwork, d.auth)
+	resp, err := d.network.FreeNetwork(releaseNetwork, nil)
 	if err != nil {
 		return response, err
 	}
@@ -322,7 +322,7 @@ func (d *Driver) NetworkDelete(id string) (*NetworkDetailResponse, error) {
 	deleteNetwork := network.NewDeleteNetworkParams()
 
 	deleteNetwork.ID = id
-	resp, err := d.network.DeleteNetwork(deleteNetwork, d.auth)
+	resp, err := d.network.DeleteNetwork(deleteNetwork, nil)
 	if err != nil {
 		return response, err
 	}
@@ -343,7 +343,7 @@ func (d *Driver) NetworkUpdate(ncr *NetworkCreateRequest) (*NetworkDetailRespons
 		Labels:      ncr.Labels,
 	}
 	updateNetwork.SetBody(updateRequest)
-	resp, err := d.network.UpdateNetwork(updateNetwork, d.auth)
+	resp, err := d.network.UpdateNetwork(updateNetwork, nil)
 	if err != nil {
 		return response, err
 	}
@@ -367,7 +367,7 @@ func (d *Driver) NetworkAddPrefix(nur *NetworkUpdateRequest) (*NetworkDetailResp
 		Prefixes: newPrefixes,
 	}
 	updateNetwork.SetBody(updateRequest)
-	resp, err := d.network.UpdateNetwork(updateNetwork, d.auth)
+	resp, err := d.network.UpdateNetwork(updateNetwork, nil)
 	if err != nil {
 		return response, err
 	}
@@ -397,7 +397,7 @@ func (d *Driver) NetworkRemovePrefix(nur *NetworkUpdateRequest) (*NetworkDetailR
 		Prefixes: newPrefixes,
 	}
 	updateNetwork.SetBody(updateRequest)
-	resp, err := d.network.UpdateNetwork(updateNetwork, d.auth)
+	resp, err := d.network.UpdateNetwork(updateNetwork, nil)
 	if err != nil {
 		return response, err
 	}
@@ -410,7 +410,7 @@ func (d *Driver) IPGet(ipaddress string) (*IPDetailResponse, error) {
 	response := &IPDetailResponse{}
 	findIP := ip.NewFindIPParams()
 	findIP.ID = ipaddress
-	resp, err := d.ip.FindIP(findIP, d.auth)
+	resp, err := d.ip.FindIP(findIP, nil)
 	if err != nil {
 		return response, err
 	}
@@ -431,7 +431,7 @@ func (d *Driver) IPUpdate(iur *IPUpdateRequest) (*IPDetailResponse, error) {
 		Tags:        iur.Tags,
 	}
 	updateIP.SetBody(updateRequest)
-	resp, err := d.ip.UpdateIP(updateIP, d.auth)
+	resp, err := d.ip.UpdateIP(updateIP, nil)
 	if err != nil {
 		return response, err
 	}
@@ -443,7 +443,7 @@ func (d *Driver) IPUpdate(iur *IPUpdateRequest) (*IPDetailResponse, error) {
 func (d *Driver) IPList() (*IPListResponse, error) {
 	response := &IPListResponse{}
 	listIPs := ip.NewListIpsParams()
-	resp, err := d.ip.ListIps(listIPs, d.auth)
+	resp, err := d.ip.ListIps(listIPs, nil)
 	if err != nil {
 		return response, err
 	}
@@ -473,7 +473,7 @@ func (d *Driver) IPFind(ifr *IPFindRequest) (*IPListResponse, error) {
 	}
 	findIPs.SetBody(req)
 
-	resp, err = d.ip.FindIps(findIPs, d.auth)
+	resp, err = d.ip.FindIps(findIPs, nil)
 	if err != nil {
 		return response, err
 	}
@@ -497,7 +497,7 @@ func (d *Driver) IPAllocate(iar *IPAllocateRequest) (*IPDetailResponse, error) {
 	if iar.IPAddress == "" {
 		acquireIP := ip.NewAllocateIPParams()
 		acquireIP.SetBody(acquireIPRequest)
-		resp, err := d.ip.AllocateIP(acquireIP, d.auth)
+		resp, err := d.ip.AllocateIP(acquireIP, nil)
 		if err != nil {
 			return response, err
 		}
@@ -506,7 +506,7 @@ func (d *Driver) IPAllocate(iar *IPAllocateRequest) (*IPDetailResponse, error) {
 		acquireIP := ip.NewAllocateSpecificIPParams()
 		acquireIP.IP = iar.IPAddress
 		acquireIP.SetBody(acquireIPRequest)
-		resp, err := d.ip.AllocateSpecificIP(acquireIP, d.auth)
+		resp, err := d.ip.AllocateSpecificIP(acquireIP, nil)
 		if err != nil {
 			return response, err
 		}
@@ -520,7 +520,7 @@ func (d *Driver) IPFree(id string) (*IPDetailResponse, error) {
 	response := &IPDetailResponse{}
 	deleteIP := ip.NewFreeIPParams()
 	deleteIP.ID = id
-	resp, err := d.ip.FreeIP(deleteIP, d.auth)
+	resp, err := d.ip.FreeIP(deleteIP, nil)
 	if err != nil {
 		return response, err
 	}

--- a/partition.go
+++ b/partition.go
@@ -54,7 +54,7 @@ type PartitionCreateResponse struct {
 func (d *Driver) PartitionList() (*PartitionListResponse, error) {
 	response := &PartitionListResponse{}
 	listPartitions := partition.NewListPartitionsParams()
-	resp, err := d.partition.ListPartitions(listPartitions, d.auth)
+	resp, err := d.partition.ListPartitions(listPartitions, nil)
 	if err != nil {
 		return response, err
 	}
@@ -67,7 +67,7 @@ func (d *Driver) PartitionGet(partitionID string) (*PartitionGetResponse, error)
 	response := &PartitionGetResponse{}
 	getPartition := partition.NewFindPartitionParams()
 	getPartition.ID = partitionID
-	resp, err := d.partition.FindPartition(getPartition, d.auth)
+	resp, err := d.partition.FindPartition(getPartition, nil)
 	if err != nil {
 		return response, err
 	}
@@ -79,7 +79,7 @@ func (d *Driver) PartitionGet(partitionID string) (*PartitionGetResponse, error)
 func (d *Driver) PartitionCapacity() (*PartitionCapacityResponse, error) {
 	response := &PartitionCapacityResponse{}
 	partitionParams := partition.NewPartitionCapacityParams()
-	resp, err := d.partition.PartitionCapacity(partitionParams, d.auth)
+	resp, err := d.partition.PartitionCapacity(partitionParams, nil)
 	if err != nil {
 		return response, err
 	}
@@ -101,7 +101,7 @@ func (d *Driver) PartitionCreate(pcr PartitionCreateRequest) (*PartitionCreateRe
 	}
 	request := partition.NewCreatePartitionParams()
 	request.SetBody(createPartition)
-	resp, err := d.partition.CreatePartition(request, d.auth)
+	resp, err := d.partition.CreatePartition(request, nil)
 	if err != nil {
 		return response, err
 	}
@@ -122,7 +122,7 @@ func (d *Driver) PartitionUpdate(pcr PartitionCreateRequest) (*PartitionCreateRe
 	}
 	request := partition.NewUpdatePartitionParams()
 	request.SetBody(updatePartition)
-	resp, err := d.partition.UpdatePartition(request, d.auth)
+	resp, err := d.partition.UpdatePartition(request, nil)
 	if err != nil {
 		return response, err
 	}
@@ -135,7 +135,7 @@ func (d *Driver) PartitionDelete(partitionID string) (*PartitionGetResponse, err
 	response := &PartitionGetResponse{}
 	request := partition.NewDeletePartitionParams()
 	request.ID = partitionID
-	resp, err := d.partition.DeletePartition(request, d.auth)
+	resp, err := d.partition.DeletePartition(request, nil)
 	if err != nil {
 		return response, err
 	}

--- a/project.go
+++ b/project.go
@@ -27,7 +27,7 @@ type ProjectFindRequest struct {
 func (d *Driver) ProjectList() (*ProjectListResponse, error) {
 	response := &ProjectListResponse{}
 	listProjects := project.NewListProjectsParams()
-	resp, err := d.project.ListProjects(listProjects, d.auth)
+	resp, err := d.project.ListProjects(listProjects, nil)
 	if err != nil {
 		return response, err
 	}
@@ -50,7 +50,7 @@ func (d *Driver) ProjectFind(pfr v1.ProjectFindRequest) (*ProjectListResponse, e
 		body.TenantID = *pfr.TenantId
 	}
 	findProjects.Body = body
-	resp, err := d.project.FindProjects(findProjects, d.auth)
+	resp, err := d.project.FindProjects(findProjects, nil)
 	if err != nil {
 		return response, err
 	}
@@ -63,7 +63,7 @@ func (d *Driver) ProjectGet(projectID string) (*ProjectGetResponse, error) {
 	response := &ProjectGetResponse{}
 	getProject := project.NewFindProjectParams()
 	getProject.ID = projectID
-	resp, err := d.project.FindProject(getProject, d.auth)
+	resp, err := d.project.FindProject(getProject, nil)
 	if err != nil {
 		return response, err
 	}
@@ -90,7 +90,7 @@ func (d *Driver) ProjectCreate(pcr v1.ProjectCreateRequest) (*ProjectGetResponse
 		Quotas:   ToV1QuotaSet(pcr.Quotas),
 	}
 	createProject.Body = body
-	resp, err := d.project.CreateProject(createProject, d.auth)
+	resp, err := d.project.CreateProject(createProject, nil)
 	if err != nil {
 		return response, err
 	}
@@ -117,7 +117,7 @@ func (d *Driver) ProjectUpdate(pur v1.ProjectUpdateRequest) (*ProjectGetResponse
 		Quotas:   ToV1QuotaSet(pur.Quotas),
 	}
 	updateProject.Body = body
-	resp, err := d.project.UpdateProject(updateProject, d.auth)
+	resp, err := d.project.UpdateProject(updateProject, nil)
 	if err != nil {
 		return response, err
 	}
@@ -130,7 +130,7 @@ func (d *Driver) ProjectDelete(projectID string) (*ProjectGetResponse, error) {
 	response := &ProjectGetResponse{}
 	getProject := project.NewDeleteProjectParams()
 	getProject.ID = projectID
-	resp, err := d.project.DeleteProject(getProject, d.auth)
+	resp, err := d.project.DeleteProject(getProject, nil)
 	if err != nil {
 		return response, err
 	}

--- a/size.go
+++ b/size.go
@@ -39,7 +39,7 @@ type SizeTryResponse struct {
 func (d *Driver) SizeList() (*SizeListResponse, error) {
 	response := &SizeListResponse{}
 	listSizes := size.NewListSizesParams()
-	resp, err := d.size.ListSizes(listSizes, d.auth)
+	resp, err := d.size.ListSizes(listSizes, nil)
 	if err != nil {
 		return response, err
 	}
@@ -52,7 +52,7 @@ func (d *Driver) SizeGet(sizeID string) (*SizeGetResponse, error) {
 	response := &SizeGetResponse{}
 	request := size.NewFindSizeParams()
 	request.ID = sizeID
-	resp, err := d.size.FindSize(request, d.auth)
+	resp, err := d.size.FindSize(request, nil)
 	if err != nil {
 		return response, err
 	}
@@ -80,7 +80,7 @@ func (d *Driver) SizeTry(cores int32, memory, storage uint64) (*SizeTryResponse,
 	trySize := size.NewFromHardwareParams()
 	trySize.Body = hardware
 
-	resp, err := d.size.FromHardware(trySize, d.auth)
+	resp, err := d.size.FromHardware(trySize, nil)
 	if err == nil {
 		response.Logs = []*models.V1SizeMatchingLog{resp.Payload}
 	} else {
@@ -107,7 +107,7 @@ func (d *Driver) SizeCreate(pcr SizeCreateRequest) (*SizeCreateResponse, error) 
 	}
 	request := size.NewCreateSizeParams()
 	request.SetBody(createSize)
-	resp, err := d.size.CreateSize(request, d.auth)
+	resp, err := d.size.CreateSize(request, nil)
 	if err != nil {
 		return response, err
 	}
@@ -127,7 +127,7 @@ func (d *Driver) SizeUpdate(pcr SizeCreateRequest) (*SizeCreateResponse, error) 
 	}
 	request := size.NewUpdateSizeParams()
 	request.SetBody(updateSize)
-	resp, err := d.size.UpdateSize(request, d.auth)
+	resp, err := d.size.UpdateSize(request, nil)
 	if err != nil {
 		return response, err
 	}
@@ -140,7 +140,7 @@ func (d *Driver) SizeDelete(sizeID string) (*SizeGetResponse, error) {
 	response := &SizeGetResponse{}
 	request := size.NewDeleteSizeParams()
 	request.ID = sizeID
-	resp, err := d.size.DeleteSize(request, d.auth)
+	resp, err := d.size.DeleteSize(request, nil)
 	if err != nil {
 		return response, err
 	}

--- a/switch.go
+++ b/switch.go
@@ -28,7 +28,7 @@ type SwitchUpdateRequest struct {
 func (d *Driver) SwitchList() (*SwitchListResponse, error) {
 	response := &SwitchListResponse{}
 	listSwitchs := sw.NewListSwitchesParams()
-	resp, err := d.sw.ListSwitches(listSwitchs, d.auth)
+	resp, err := d.sw.ListSwitches(listSwitchs, nil)
 	if err != nil {
 		return response, err
 	}
@@ -41,7 +41,7 @@ func (d *Driver) SwitchGet(switchID string) (*SwitchGetResponse, error) {
 	response := &SwitchGetResponse{}
 	get := sw.NewFindSwitchParams()
 	get.ID = switchID
-	resp, err := d.sw.FindSwitch(get, d.auth)
+	resp, err := d.sw.FindSwitch(get, nil)
 	if err != nil {
 		return response, err
 	}
@@ -61,7 +61,7 @@ func (d *Driver) SwitchUpdate(sur SwitchUpdateRequest) (*SwitchGetResponse, erro
 	}
 	request := sw.NewUpdateSwitchParams()
 	request.SetBody(updateSwitch)
-	resp, err := d.sw.UpdateSwitch(request, d.auth)
+	resp, err := d.sw.UpdateSwitch(request, nil)
 	if err != nil {
 		return response, err
 	}


### PR DESCRIPTION
- Removes round tripper (not required anymore because have machine allocation backed with NSQ reconcile, it destroys original error responses)
- Use default auther
- Make HMAC default auth type a constant
- Expose general client for advanced use-cases

References https://github.com/metal-stack/metalctl/pull/50 and https://github.com/metal-stack/metal-api/pull/113. 