### PR TITLE
Implementing MEP-6: Clusters with private networks only / DMZ

### DIFF
--- a/api/models/v1_ip_find_request.go
+++ b/api/models/v1_ip_find_request.go
@@ -23,6 +23,9 @@ type V1IPFindRequest struct {
 	// the machine an ip address is associated to
 	Machineid string `json:"machineid,omitempty"`
 
+	// the name of the ip address
+	Name string `json:"name,omitempty"`
+
 	// the network this ip allocate request address belongs to
 	Networkid string `json:"networkid,omitempty"`
 

--- a/api/models/v1_network_allocate_request.go
+++ b/api/models/v1_network_allocate_request.go
@@ -29,6 +29,9 @@ type V1NetworkAllocateRequest struct {
 	// a readable name for this entity
 	Name string `json:"name,omitempty"`
 
+	// if set to true, packets leaving this network get masqueraded behind interface ip
+	Nat bool `json:"nat,omitempty"`
+
 	// the partition this network belongs to
 	Partitionid string `json:"partitionid,omitempty"`
 

--- a/api/models/v1_network_allocate_request.go
+++ b/api/models/v1_network_allocate_request.go
@@ -20,6 +20,9 @@ type V1NetworkAllocateRequest struct {
 	// a description for this entity
 	Description string `json:"description,omitempty"`
 
+	// the destination prefixes of this network
+	Destinationprefixes []string `json:"destinationprefixes"`
+
 	// free labels that you associate with this network.
 	Labels map[string]string `json:"labels,omitempty"`
 

--- a/metal-api.json
+++ b/metal-api.json
@@ -2018,6 +2018,10 @@
           "description": "a readable name for this entity",
           "type": "string"
         },
+        "nat": {
+          "description": "if set to true, packets leaving this network get masqueraded behind interface ip",
+          "type": "boolean"
+        },
         "partitionid": {
           "description": "the partition this network belongs to",
           "type": "string"

--- a/metal-api.json
+++ b/metal-api.json
@@ -546,6 +546,10 @@
           "description": "the machine an ip address is associated to",
           "type": "string"
         },
+        "name": {
+          "description": "the name of the ip address",
+          "type": "string"
+        },
         "networkid": {
           "description": "the network this ip allocate request address belongs to",
           "type": "string"
@@ -1995,6 +1999,13 @@
         "description": {
           "description": "a description for this entity",
           "type": "string"
+        },
+        "destinationprefixes": {
+          "description": "the destination prefixes of this network",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "labels": {
           "additionalProperties": {

--- a/network.go
+++ b/network.go
@@ -55,7 +55,7 @@ type NetworkAllocateRequest struct {
 
 	// the destination prefixes of this network
 	// Required: false
-	Destinationprefixes []string `json:"destinationprefixes"`
+	Destinationprefixes []string `json:"destinationprefixes,omitempty"`
 }
 
 // NetworkCreateRequest is the request for create a new network

--- a/network.go
+++ b/network.go
@@ -48,6 +48,10 @@ type NetworkAllocateRequest struct {
 	// A map of key/value pairs treated as labels.
 	// Required: false
 	Labels map[string]string `json:"labels"`
+
+	// the destination prefixes of this network
+	// Required: false
+	Destinationprefixes []string `json:"destinationprefixes"`
 }
 
 // NetworkCreateRequest is the request for create a new network
@@ -292,12 +296,13 @@ func (d *Driver) NetworkAllocate(ncr *NetworkAllocateRequest) (*NetworkDetailRes
 	acquireNetwork := network.NewAllocateNetworkParams()
 
 	acquireRequest := &models.V1NetworkAllocateRequest{
-		Description: ncr.Description,
-		Name:        ncr.Name,
-		Partitionid: ncr.PartitionID,
-		Projectid:   ncr.ProjectID,
-		Shared:      ncr.Shared,
-		Labels:      ncr.Labels,
+		Description:         ncr.Description,
+		Name:                ncr.Name,
+		Partitionid:         ncr.PartitionID,
+		Projectid:           ncr.ProjectID,
+		Shared:              ncr.Shared,
+		Labels:              ncr.Labels,
+		Destinationprefixes: ncr.Destinationprefixes,
 	}
 	acquireNetwork.SetBody(acquireRequest)
 	resp, err := d.network.AllocateNetwork(acquireNetwork, nil)

--- a/network.go
+++ b/network.go
@@ -305,6 +305,7 @@ func (d *Driver) NetworkAllocate(ncr *NetworkAllocateRequest) (*NetworkDetailRes
 		Partitionid:         ncr.PartitionID,
 		Projectid:           ncr.ProjectID,
 		Shared:              ncr.Shared,
+		Nat:                 ncr.Nat,
 		Labels:              ncr.Labels,
 		Destinationprefixes: ncr.Destinationprefixes,
 	}

--- a/network.go
+++ b/network.go
@@ -45,6 +45,10 @@ type NetworkAllocateRequest struct {
 	// Required: false
 	Shared bool `json:"shared,omitempty"`
 
+	// Packets leaving this network get masqueraded
+	// Required: false
+	Nat bool `json:"nat,omitempty"`
+
 	// A map of key/value pairs treated as labels.
 	// Required: false
 	Labels map[string]string `json:"labels"`


### PR DESCRIPTION
Allow to specify `nat` and `destinationPrefixes` with `NetworkAllocateRequest`