### PR TITLE
New fields to detect crash loop and failed machine reclaim

### DIFF
--- a/api/client/ip/allocate_ip_responses.go
+++ b/api/client/ip/allocate_ip_responses.go
@@ -30,6 +30,12 @@ func (o *AllocateIPReader) ReadResponse(response runtime.ClientResponse, consume
 			return nil, err
 		}
 		return result, nil
+	case 409:
+		result := NewAllocateIPConflict()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		result := NewAllocateIPDefault(response.Code())
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -65,6 +71,38 @@ func (o *AllocateIPCreated) GetPayload() *models.V1IPResponse {
 func (o *AllocateIPCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.V1IPResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewAllocateIPConflict creates a AllocateIPConflict with default headers values
+func NewAllocateIPConflict() *AllocateIPConflict {
+	return &AllocateIPConflict{}
+}
+
+/* AllocateIPConflict describes a response with status code 409, with default header values.
+
+Conflict
+*/
+type AllocateIPConflict struct {
+	Payload *httperrors.HTTPErrorResponse
+}
+
+func (o *AllocateIPConflict) Error() string {
+	return fmt.Sprintf("[POST /v1/ip/allocate][%d] allocateIpConflict  %+v", 409, o.Payload)
+}
+func (o *AllocateIPConflict) GetPayload() *httperrors.HTTPErrorResponse {
+	return o.Payload
+}
+
+func (o *AllocateIPConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(httperrors.HTTPErrorResponse)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/api/client/ip/allocate_specific_ip_responses.go
+++ b/api/client/ip/allocate_specific_ip_responses.go
@@ -30,6 +30,12 @@ func (o *AllocateSpecificIPReader) ReadResponse(response runtime.ClientResponse,
 			return nil, err
 		}
 		return result, nil
+	case 409:
+		result := NewAllocateSpecificIPConflict()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		result := NewAllocateSpecificIPDefault(response.Code())
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -65,6 +71,38 @@ func (o *AllocateSpecificIPCreated) GetPayload() *models.V1IPResponse {
 func (o *AllocateSpecificIPCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.V1IPResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewAllocateSpecificIPConflict creates a AllocateSpecificIPConflict with default headers values
+func NewAllocateSpecificIPConflict() *AllocateSpecificIPConflict {
+	return &AllocateSpecificIPConflict{}
+}
+
+/* AllocateSpecificIPConflict describes a response with status code 409, with default header values.
+
+Conflict
+*/
+type AllocateSpecificIPConflict struct {
+	Payload *httperrors.HTTPErrorResponse
+}
+
+func (o *AllocateSpecificIPConflict) Error() string {
+	return fmt.Sprintf("[POST /v1/ip/allocate/{ip}][%d] allocateSpecificIpConflict  %+v", 409, o.Payload)
+}
+func (o *AllocateSpecificIPConflict) GetPayload() *httperrors.HTTPErrorResponse {
+	return o.Payload
+}
+
+func (o *AllocateSpecificIPConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(httperrors.HTTPErrorResponse)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/api/models/v1_machine_recent_provisioning_events.go
+++ b/api/models/v1_machine_recent_provisioning_events.go
@@ -20,7 +20,15 @@ import (
 // swagger:model v1.MachineRecentProvisioningEvents
 type V1MachineRecentProvisioningEvents struct {
 
-	// the amount of incomplete provisioning cycles in the event container
+	// indicates that machine is provisioning crash loop
+	// Required: true
+	CrashLoop *bool `json:"crash_loop"`
+
+	// indicates that machine reclaim has failed
+	// Required: true
+	FailedMachineReclaim *bool `json:"failed_machine_reclaim"`
+
+	// The field 'IncompleteProvisioningCycles' in the provisioning events container is now deprecated and replaced by two new bool flags 'CrashLoop' and 'MachineReclaimFailed'.
 	// Required: true
 	IncompleteProvisioningCycles *string `json:"incomplete_provisioning_cycles"`
 
@@ -37,6 +45,14 @@ type V1MachineRecentProvisioningEvents struct {
 func (m *V1MachineRecentProvisioningEvents) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateCrashLoop(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateFailedMachineReclaim(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateIncompleteProvisioningCycles(formats); err != nil {
 		res = append(res, err)
 	}
@@ -52,6 +68,24 @@ func (m *V1MachineRecentProvisioningEvents) Validate(formats strfmt.Registry) er
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *V1MachineRecentProvisioningEvents) validateCrashLoop(formats strfmt.Registry) error {
+
+	if err := validate.Required("crash_loop", "body", m.CrashLoop); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *V1MachineRecentProvisioningEvents) validateFailedMachineReclaim(formats strfmt.Registry) error {
+
+	if err := validate.Required("failed_machine_reclaim", "body", m.FailedMachineReclaim); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/api/models/v1_machine_recent_provisioning_events.go
+++ b/api/models/v1_machine_recent_provisioning_events.go
@@ -32,6 +32,9 @@ type V1MachineRecentProvisioningEvents struct {
 	// Required: true
 	IncompleteProvisioningCycles *string `json:"incomplete_provisioning_cycles"`
 
+	// the last erroneous event received
+	LastErrorEvent *V1MachineProvisioningEvent `json:"last_error_event,omitempty"`
+
 	// the time where the last event was received
 	// Format: date-time
 	LastEventTime strfmt.DateTime `json:"last_event_time,omitempty"`
@@ -54,6 +57,10 @@ func (m *V1MachineRecentProvisioningEvents) Validate(formats strfmt.Registry) er
 	}
 
 	if err := m.validateIncompleteProvisioningCycles(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateLastErrorEvent(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -93,6 +100,25 @@ func (m *V1MachineRecentProvisioningEvents) validateIncompleteProvisioningCycles
 
 	if err := validate.Required("incomplete_provisioning_cycles", "body", m.IncompleteProvisioningCycles); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (m *V1MachineRecentProvisioningEvents) validateLastErrorEvent(formats strfmt.Registry) error {
+	if swag.IsZero(m.LastErrorEvent) { // not required
+		return nil
+	}
+
+	if m.LastErrorEvent != nil {
+		if err := m.LastErrorEvent.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("last_error_event")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("last_error_event")
+			}
+			return err
+		}
 	}
 
 	return nil
@@ -141,6 +167,10 @@ func (m *V1MachineRecentProvisioningEvents) validateLog(formats strfmt.Registry)
 func (m *V1MachineRecentProvisioningEvents) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.contextValidateLastErrorEvent(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateLog(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -148,6 +178,22 @@ func (m *V1MachineRecentProvisioningEvents) ContextValidate(ctx context.Context,
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *V1MachineRecentProvisioningEvents) contextValidateLastErrorEvent(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.LastErrorEvent != nil {
+		if err := m.LastErrorEvent.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("last_error_event")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("last_error_event")
+			}
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/api/models/v1_machine_state.go
+++ b/api/models/v1_machine_state.go
@@ -7,6 +7,7 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
@@ -29,6 +30,7 @@ type V1MachineState struct {
 
 	// the state of this machine. empty means available for all
 	// Required: true
+	// Enum: [ LOCKED RESERVED]
 	Value *string `json:"value"`
 }
 
@@ -72,9 +74,46 @@ func (m *V1MachineState) validateMetalHammerVersion(formats strfmt.Registry) err
 	return nil
 }
 
+var v1MachineStateTypeValuePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["","LOCKED","RESERVED"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		v1MachineStateTypeValuePropEnum = append(v1MachineStateTypeValuePropEnum, v)
+	}
+}
+
+const (
+
+	// V1MachineStateValueEmpty captures enum value ""
+	V1MachineStateValueEmpty string = ""
+
+	// V1MachineStateValueLOCKED captures enum value "LOCKED"
+	V1MachineStateValueLOCKED string = "LOCKED"
+
+	// V1MachineStateValueRESERVED captures enum value "RESERVED"
+	V1MachineStateValueRESERVED string = "RESERVED"
+)
+
+// prop value enum
+func (m *V1MachineState) validateValueEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, v1MachineStateTypeValuePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *V1MachineState) validateValue(formats strfmt.Registry) error {
 
 	if err := validate.Required("value", "body", m.Value); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := m.validateValueEnum("value", "body", *m.Value); err != nil {
 		return err
 	}
 

--- a/api/models/v1_machine_update_firmware_request.go
+++ b/api/models/v1_machine_update_firmware_request.go
@@ -7,6 +7,7 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
@@ -25,6 +26,7 @@ type V1MachineUpdateFirmwareRequest struct {
 
 	// the firmware kind, i.e. [bios|bmc]
 	// Required: true
+	// Enum: [bios bmc]
 	Kind *string `json:"kind"`
 
 	// the update revision
@@ -63,9 +65,43 @@ func (m *V1MachineUpdateFirmwareRequest) validateDescription(formats strfmt.Regi
 	return nil
 }
 
+var v1MachineUpdateFirmwareRequestTypeKindPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["bios","bmc"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		v1MachineUpdateFirmwareRequestTypeKindPropEnum = append(v1MachineUpdateFirmwareRequestTypeKindPropEnum, v)
+	}
+}
+
+const (
+
+	// V1MachineUpdateFirmwareRequestKindBios captures enum value "bios"
+	V1MachineUpdateFirmwareRequestKindBios string = "bios"
+
+	// V1MachineUpdateFirmwareRequestKindBmc captures enum value "bmc"
+	V1MachineUpdateFirmwareRequestKindBmc string = "bmc"
+)
+
+// prop value enum
+func (m *V1MachineUpdateFirmwareRequest) validateKindEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, v1MachineUpdateFirmwareRequestTypeKindPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *V1MachineUpdateFirmwareRequest) validateKind(formats strfmt.Registry) error {
 
 	if err := validate.Required("kind", "body", m.Kind); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := m.validateKindEnum("kind", "body", *m.Kind); err != nil {
 		return err
 	}
 

--- a/filesystem.go
+++ b/filesystem.go
@@ -8,10 +8,12 @@ import (
 // FilesystemLayoutList return all machine filesystemlayouts
 func (d *Driver) FilesystemLayoutList() ([]*models.V1FilesystemLayoutResponse, error) {
 	listFilesystemLayouts := filesystemlayout.NewListFilesystemLayoutsParams()
+
 	resp, err := d.Filesystemlayout().ListFilesystemLayouts(listFilesystemLayouts, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	return resp.Payload, nil
 }
 
@@ -19,10 +21,12 @@ func (d *Driver) FilesystemLayoutList() ([]*models.V1FilesystemLayoutResponse, e
 func (d *Driver) FilesystemLayoutGet(filesystemlayoutID string) (*models.V1FilesystemLayoutResponse, error) {
 	request := filesystemlayout.NewGetFilesystemLayoutParams()
 	request.ID = filesystemlayoutID
+
 	resp, err := d.Filesystemlayout().GetFilesystemLayout(request, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	return resp.Payload, nil
 }
 
@@ -30,10 +34,12 @@ func (d *Driver) FilesystemLayoutGet(filesystemlayoutID string) (*models.V1Files
 func (d *Driver) FilesystemLayoutCreate(fcr models.V1FilesystemLayoutCreateRequest) (*models.V1FilesystemLayoutResponse, error) {
 	request := filesystemlayout.NewCreateFilesystemLayoutParams()
 	request.SetBody(&fcr)
+
 	resp, err := d.Filesystemlayout().CreateFilesystemLayout(request, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	return resp.Payload, nil
 }
 
@@ -41,10 +47,12 @@ func (d *Driver) FilesystemLayoutCreate(fcr models.V1FilesystemLayoutCreateReque
 func (d *Driver) FilesystemLayoutUpdate(fur models.V1FilesystemLayoutUpdateRequest) (*models.V1FilesystemLayoutResponse, error) {
 	request := filesystemlayout.NewUpdateFilesystemLayoutParams()
 	request.SetBody(&fur)
+
 	resp, err := d.Filesystemlayout().UpdateFilesystemLayout(request, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	return resp.Payload, nil
 }
 
@@ -52,10 +60,12 @@ func (d *Driver) FilesystemLayoutUpdate(fur models.V1FilesystemLayoutUpdateReque
 func (d *Driver) FilesystemLayoutDelete(filesystemlayoutID string) (*models.V1FilesystemLayoutResponse, error) {
 	request := filesystemlayout.NewDeleteFilesystemLayoutParams()
 	request.ID = filesystemlayoutID
+
 	resp, err := d.Filesystemlayout().DeleteFilesystemLayout(request, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	return resp.Payload, nil
 }
 
@@ -63,10 +73,12 @@ func (d *Driver) FilesystemLayoutDelete(filesystemlayoutID string) (*models.V1Fi
 func (d *Driver) FilesystemLayoutTry(try models.V1FilesystemLayoutTryRequest) (*models.V1FilesystemLayoutResponse, error) {
 	request := filesystemlayout.NewTryFilesystemLayoutParams()
 	request.SetBody(&try)
+
 	resp, err := d.Filesystemlayout().TryFilesystemLayout(request, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	return resp.Payload, nil
 }
 
@@ -74,9 +86,11 @@ func (d *Driver) FilesystemLayoutTry(try models.V1FilesystemLayoutTryRequest) (*
 func (d *Driver) FilesystemLayoutMatch(match models.V1FilesystemLayoutMatchRequest) (*models.V1FilesystemLayoutResponse, error) {
 	request := filesystemlayout.NewMatchFilesystemLayoutParams()
 	request.SetBody(&match)
+
 	resp, err := d.Filesystemlayout().MatchFilesystemLayout(request, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	return resp.Payload, nil
 }

--- a/machine_test.go
+++ b/machine_test.go
@@ -89,7 +89,7 @@ func startServerAndGetDriver() (*http.Server, Client, *Driver) {
 	//nolint:gosec
 	listener, _ := net.Listen("tcp", ":0")
 
-	server := &http.Server{}
+	server := &http.Server{ReadHeaderTimeout: time.Minute}
 
 	go func() {
 		_ = server.Serve(listener)

--- a/metal-api.json
+++ b/metal-api.json
@@ -2707,6 +2707,10 @@
           "description": "The field 'IncompleteProvisioningCycles' in the provisioning events container is now deprecated and replaced by two new bool flags 'CrashLoop' and 'MachineReclaimFailed'.",
           "type": "string"
         },
+        "last_error_event": {
+          "$ref": "#/definitions/v1.MachineProvisioningEvent",
+          "description": "the last erroneous event received"
+        },
         "last_event_time": {
           "description": "the time where the last event was received",
           "format": "date-time",
@@ -5505,6 +5509,12 @@
               "$ref": "#/definitions/v1.IPResponse"
             }
           },
+          "409": {
+            "description": "Conflict",
+            "schema": {
+              "$ref": "#/definitions/httperrors.HTTPErrorResponse"
+            }
+          },
           "default": {
             "description": "Error",
             "schema": {
@@ -5549,6 +5559,12 @@
             "description": "Created",
             "schema": {
               "$ref": "#/definitions/v1.IPResponse"
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "schema": {
+              "$ref": "#/definitions/httperrors.HTTPErrorResponse"
             }
           },
           "default": {

--- a/metal-api.json
+++ b/metal-api.json
@@ -2695,8 +2695,16 @@
     },
     "v1.MachineRecentProvisioningEvents": {
       "properties": {
+        "crash_loop": {
+          "description": "indicates that machine is provisioning crash loop",
+          "type": "boolean"
+        },
+        "failed_machine_reclaim": {
+          "description": "indicates that machine reclaim has failed",
+          "type": "boolean"
+        },
         "incomplete_provisioning_cycles": {
-          "description": "the amount of incomplete provisioning cycles in the event container",
+          "description": "The field 'IncompleteProvisioningCycles' in the provisioning events container is now deprecated and replaced by two new bool flags 'CrashLoop' and 'MachineReclaimFailed'.",
           "type": "string"
         },
         "last_event_time": {
@@ -2713,6 +2721,8 @@
         }
       },
       "required": [
+        "crash_loop",
+        "failed_machine_reclaim",
         "incomplete_provisioning_cycles",
         "log"
       ]
@@ -2907,6 +2917,11 @@
         },
         "value": {
           "description": "the state of this machine. empty means available for all",
+          "enum": [
+            "",
+            "LOCKED",
+            "RESERVED"
+          ],
           "type": "string"
         }
       },
@@ -2924,6 +2939,10 @@
         },
         "kind": {
           "description": "the firmware kind, i.e. [bios|bmc]",
+          "enum": [
+            "bios",
+            "bmc"
+          ],
           "type": "string"
         },
         "revision": {

--- a/sizeimageconstraint.go
+++ b/sizeimageconstraint.go
@@ -7,7 +7,6 @@ import (
 
 // TrySizeImageConstraint try if size and image can be used for a allocation
 func (d *Driver) TrySizeImageConstraint(size, image string) error {
-
 	params := sizeimageconstraint.NewTrySizeImageConstraintParams().WithBody(&models.V1SizeImageConstraintTryRequest{
 		Size:  &size,
 		Image: &image,

--- a/tenant.go
+++ b/tenant.go
@@ -35,10 +35,10 @@ func (d *Driver) TenantList() (*TenantListResponse, error) {
 }
 
 // TenantGet return a Tenant
-func (d *Driver) TenantGet(TenantID string) (*TenantGetResponse, error) {
+func (d *Driver) TenantGet(tenantID string) (*TenantGetResponse, error) {
 	response := &TenantGetResponse{}
 	getTenant := tenant.NewGetTenantParams()
-	getTenant.ID = TenantID
+	getTenant.ID = tenantID
 	resp, err := d.Tenant().GetTenant(getTenant, nil)
 	if err != nil {
 		return response, err

--- a/test/client/mock_client.go
+++ b/test/client/mock_client.go
@@ -100,55 +100,57 @@ func NewMetalMockClient(mockFns *MetalMockFns) (*MetalMockClient, metalgo.Client
 		version:             versionmocks.ClientService{},
 	}
 
-	if mockFns != nil {
-		if mockFns.Filesystemlayout != nil {
-			mockFns.Filesystemlayout(&client.filesystemlayout.Mock)
-		}
-		if mockFns.Firewall != nil {
-			mockFns.Firewall(&client.firewall.Mock)
-		}
-		if mockFns.Firmware != nil {
-			mockFns.Firmware(&client.firmware.Mock)
-		}
-		if mockFns.Health != nil {
-			mockFns.Health(&client.health.Mock)
-		}
-		if mockFns.Image != nil {
-			mockFns.Image(&client.image.Mock)
-		}
-		if mockFns.IP != nil {
-			mockFns.IP(&client.ip.Mock)
-		}
-		if mockFns.Machine != nil {
-			mockFns.Machine(&client.machine.Mock)
-		}
-		if mockFns.Network != nil {
-			mockFns.Network(&client.network.Mock)
-		}
-		if mockFns.Partition != nil {
-			mockFns.Partition(&client.partition.Mock)
-		}
-		if mockFns.Project != nil {
-			mockFns.Project(&client.project.Mock)
-		}
-		if mockFns.Size != nil {
-			mockFns.Size(&client.size.Mock)
-		}
-		if mockFns.SizeImageConstraint != nil {
-			mockFns.SizeImageConstraint(&client.sizeimageconstraint.Mock)
-		}
-		if mockFns.Switch != nil {
-			mockFns.Switch(&client.switchoperations.Mock)
-		}
-		if mockFns.Tenant != nil {
-			mockFns.Tenant(&client.tenant.Mock)
-		}
-		if mockFns.User != nil {
-			mockFns.User(&client.user.Mock)
-		}
-		if mockFns.Version != nil {
-			mockFns.Version(&client.version.Mock)
-		}
+	if mockFns == nil {
+		return client, client
+	}
+
+	if mockFns.Filesystemlayout != nil {
+		mockFns.Filesystemlayout(&client.filesystemlayout.Mock)
+	}
+	if mockFns.Firewall != nil {
+		mockFns.Firewall(&client.firewall.Mock)
+	}
+	if mockFns.Firmware != nil {
+		mockFns.Firmware(&client.firmware.Mock)
+	}
+	if mockFns.Health != nil {
+		mockFns.Health(&client.health.Mock)
+	}
+	if mockFns.Image != nil {
+		mockFns.Image(&client.image.Mock)
+	}
+	if mockFns.IP != nil {
+		mockFns.IP(&client.ip.Mock)
+	}
+	if mockFns.Machine != nil {
+		mockFns.Machine(&client.machine.Mock)
+	}
+	if mockFns.Network != nil {
+		mockFns.Network(&client.network.Mock)
+	}
+	if mockFns.Partition != nil {
+		mockFns.Partition(&client.partition.Mock)
+	}
+	if mockFns.Project != nil {
+		mockFns.Project(&client.project.Mock)
+	}
+	if mockFns.Size != nil {
+		mockFns.Size(&client.size.Mock)
+	}
+	if mockFns.SizeImageConstraint != nil {
+		mockFns.SizeImageConstraint(&client.sizeimageconstraint.Mock)
+	}
+	if mockFns.Switch != nil {
+		mockFns.Switch(&client.switchoperations.Mock)
+	}
+	if mockFns.Tenant != nil {
+		mockFns.Tenant(&client.tenant.Mock)
+	}
+	if mockFns.User != nil {
+		mockFns.User(&client.user.Mock)
+	}
+	if mockFns.Version != nil {
+		mockFns.Version(&client.version.Mock)
 	}
 
 	return client, client


### PR DESCRIPTION
Adds new fields crash_loop and failed_machine_reclaim to MachineProvisioningEvents as introduced [here](https://github.com/metal-stack/metal-api/pull/265)