### PR TITLE
Persist user email who locked or reserved a machine in DB metal-stack/metal-api#303

### DIFF
--- a/api/models/v1_machine_state.go
+++ b/api/models/v1_machine_state.go
@@ -25,8 +25,7 @@ type V1MachineState struct {
 	Description *string `json:"description"`
 
 	// the user that changed the state
-	// Required: true
-	Issuer *string `json:"issuer"`
+	Issuer string `json:"issuer,omitempty"`
 
 	// the version of metal hammer which put the machine in waiting state
 	// Required: true
@@ -43,10 +42,6 @@ func (m *V1MachineState) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateDescription(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateIssuer(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -67,15 +62,6 @@ func (m *V1MachineState) Validate(formats strfmt.Registry) error {
 func (m *V1MachineState) validateDescription(formats strfmt.Registry) error {
 
 	if err := validate.Required("description", "body", m.Description); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *V1MachineState) validateIssuer(formats strfmt.Registry) error {
-
-	if err := validate.Required("issuer", "body", m.Issuer); err != nil {
 		return err
 	}
 

--- a/api/models/v1_machine_state.go
+++ b/api/models/v1_machine_state.go
@@ -24,6 +24,10 @@ type V1MachineState struct {
 	// Required: true
 	Description *string `json:"description"`
 
+	// the user that changed the state
+	// Required: true
+	Issuer *string `json:"issuer"`
+
 	// the version of metal hammer which put the machine in waiting state
 	// Required: true
 	MetalHammerVersion *string `json:"metal_hammer_version"`
@@ -39,6 +43,10 @@ func (m *V1MachineState) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateDescription(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateIssuer(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -59,6 +67,15 @@ func (m *V1MachineState) Validate(formats strfmt.Registry) error {
 func (m *V1MachineState) validateDescription(formats strfmt.Registry) error {
 
 	if err := validate.Required("description", "body", m.Description); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *V1MachineState) validateIssuer(formats strfmt.Registry) error {
+
+	if err := validate.Required("issuer", "body", m.Issuer); err != nil {
 		return err
 	}
 

--- a/metal-api.json
+++ b/metal-api.json
@@ -2935,7 +2935,6 @@
       },
       "required": [
         "description",
-        "issuer",
         "metal_hammer_version",
         "value"
       ]

--- a/metal-api.json
+++ b/metal-api.json
@@ -2915,6 +2915,10 @@
           "description": "a description why this machine is in the given state",
           "type": "string"
         },
+        "issuer": {
+          "description": "the user that changed the state",
+          "type": "string"
+        },
         "metal_hammer_version": {
           "description": "the version of metal hammer which put the machine in waiting state",
           "type": "string"
@@ -2931,6 +2935,7 @@
       },
       "required": [
         "description",
+        "issuer",
         "metal_hammer_version",
         "value"
       ]


### PR DESCRIPTION
When locking or reserving a specific machine, the metal-api additionally tracks the email address of the state change issuer.
This allows other users to directly contact the issuer in case they need additional information. Closes #303.

This PR requires additional changes in other repositories:

- metal-stack/metal-api#317: tracking the issuer and provide access via api
- metal-stack/metal-go#89: reflects the added issuer field of the api
- metal-stack/metalctl _(pr after merge)_: bump metal-go dependency (requires metal-go release)

As a new response field has been added to the api, this probably requires a minor update.

**How to test?**

_To use the updated metalctl, bump the metal-go version in `go.mod`, e.g. with `replace github.com/metal-stack/metal-go => ../metal-go`_

- assumes you have a running metal stack (e.g. mini-lab) and the fitting environment (`eval $(make dev-env)` from mini-lab)
- with new metalctl against old metal-api: `go run . machine describe $id` should work except issuer
- deploy this metal-api (`make mini-lab-push`)
- use the metalctl with a locally bumped metal-go version
- with new or old metalctl: `go run . machine lock $id`
- with new metalctl to see issue: `go run . machine describe $id`
